### PR TITLE
Add `mps_deep_copy`

### DIFF
--- a/src/state/mps.c
+++ b/src/state/mps.c
@@ -72,15 +72,15 @@ void delete_mps(struct mps* mps)
 void copy_mps(const struct mps *mps, struct mps *ret)
 {
 	ret->d = mps->d;
-    ret->nsites = mps->nsites;
-    ret->a = ct_malloc(mps->nsites * sizeof(struct block_sparse_tensor));
+	ret->nsites = mps->nsites;
+	ret->a = ct_malloc(mps->nsites * sizeof(struct block_sparse_tensor));
 	
-    ret->qsite = ct_malloc(mps->d * sizeof(qnumber));
+	ret->qsite = ct_malloc(mps->d * sizeof(qnumber));
 	memcpy(ret->qsite, mps->qsite, mps->d * sizeof(qnumber));
 
-    for (size_t i = 0; i < mps->nsites; i++) {
-        copy_block_sparse_tensor(&mps->a[i], &ret->a[i]);
-    }
+	for (size_t i = 0; i < mps->nsites; i++) {
+		copy_block_sparse_tensor(&mps->a[i], &ret->a[i]);
+	}
 }
 
 

--- a/src/state/mps.c
+++ b/src/state/mps.c
@@ -64,6 +64,7 @@ void delete_mps(struct mps* mps)
 	mps->d = 0;
 }
 
+
 //________________________________________________________________________________________________________________________
 ///
 /// \brief Copy a matrix product state and its block sparse tensors.
@@ -74,8 +75,7 @@ void mps_deep_copy(const struct mps *mps, struct mps *ret)
     ret->nsites = mps->nsites;
     ret->qsite = ct_malloc(mps->nsites * sizeof(qnumber));
     ret->a = ct_malloc(mps->nsites * sizeof(struct block_sparse_tensor));
-    for (size_t i = 0; i < mps->nsites; i++)
-    {
+    for (size_t i = 0; i < mps->nsites; i++) {
         ret->qsite[i] = mps->qsite[i];
         copy_block_sparse_tensor(&mps->a[i], &ret->a[i]);
     }

--- a/src/state/mps.c
+++ b/src/state/mps.c
@@ -64,6 +64,23 @@ void delete_mps(struct mps* mps)
 	mps->d = 0;
 }
 
+//________________________________________________________________________________________________________________________
+///
+/// \brief Copy a matrix product state and its block sparse tensors.
+///
+void mps_deep_copy(const struct mps *mps, struct mps *ret)
+{
+    ret->d = mps->d;
+    ret->nsites = mps->nsites;
+    ret->qsite = ct_malloc(mps->nsites * sizeof(qnumber));
+    ret->a = ct_malloc(mps->nsites * sizeof(struct block_sparse_tensor));
+    for (size_t i = 0; i < mps->nsites; i++)
+    {
+        ret->qsite[i] = mps->qsite[i];
+        copy_block_sparse_tensor(&mps->a[i], &ret->a[i]);
+    }
+}
+
 
 //________________________________________________________________________________________________________________________
 ///

--- a/src/state/mps.c
+++ b/src/state/mps.c
@@ -69,14 +69,16 @@ void delete_mps(struct mps* mps)
 ///
 /// \brief Copy a matrix product state and its block sparse tensors.
 ///
-void mps_deep_copy(const struct mps *mps, struct mps *ret)
+void copy_mps(const struct mps *mps, struct mps *ret)
 {
-    ret->d = mps->d;
+	ret->d = mps->d;
     ret->nsites = mps->nsites;
-    ret->qsite = ct_malloc(mps->nsites * sizeof(qnumber));
     ret->a = ct_malloc(mps->nsites * sizeof(struct block_sparse_tensor));
+	
+    ret->qsite = ct_malloc(mps->d * sizeof(qnumber));
+	memcpy(ret->qsite, mps->qsite, mps->d * sizeof(qnumber));
+
     for (size_t i = 0; i < mps->nsites; i++) {
-        ret->qsite[i] = mps->qsite[i];
         copy_block_sparse_tensor(&mps->a[i], &ret->a[i]);
     }
 }

--- a/src/state/mps.c
+++ b/src/state/mps.c
@@ -69,7 +69,7 @@ void delete_mps(struct mps* mps)
 ///
 /// \brief Copy a matrix product state and its block sparse tensors.
 ///
-void copy_mps(const struct mps *mps, struct mps *ret)
+void copy_mps(const struct mps* mps, struct mps* ret)
 {
 	ret->d = mps->d;
 	ret->nsites = mps->nsites;

--- a/src/state/mps.h
+++ b/src/state/mps.h
@@ -35,7 +35,7 @@ void construct_random_mps(const enum numeric_type dtype, const int nsites, const
 
 bool mps_is_consistent(const struct mps* mps);
 
-void copy_mps(const struct mps *mps, struct mps *ret);
+void copy_mps(const struct mps* mps, struct mps* ret);
 
 
 //________________________________________________________________________________________________________________________

--- a/src/state/mps.h
+++ b/src/state/mps.h
@@ -35,6 +35,8 @@ void construct_random_mps(const enum numeric_type dtype, const int nsites, const
 
 bool mps_is_consistent(const struct mps* mps);
 
+void mps_deep_copy(const struct mps *mps, struct mps *ret);
+
 
 //________________________________________________________________________________________________________________________
 ///

--- a/src/state/mps.h
+++ b/src/state/mps.h
@@ -35,7 +35,7 @@ void construct_random_mps(const enum numeric_type dtype, const int nsites, const
 
 bool mps_is_consistent(const struct mps* mps);
 
-void mps_deep_copy(const struct mps *mps, struct mps *ret);
+void copy_mps(const struct mps *mps, struct mps *ret);
 
 
 //________________________________________________________________________________________________________________________

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -57,6 +57,7 @@ char* test_mps_orthonormalize_qr();
 char* test_mps_compress();
 char* test_mps_split_tensor_svd();
 char* test_mps_to_statevector();
+char* test_mps_deep_copy();
 char* test_ttns_vdot();
 char* test_queue();
 char* test_linked_list();
@@ -143,6 +144,7 @@ int main()
 		TEST_FUNCTION_ENTRY(test_mps_compress),
 		TEST_FUNCTION_ENTRY(test_mps_split_tensor_svd),
 		TEST_FUNCTION_ENTRY(test_mps_to_statevector),
+		TEST_FUNCTION_ENTRY(test_mps_deep_copy),
 		TEST_FUNCTION_ENTRY(test_ttns_vdot),
 		TEST_FUNCTION_ENTRY(test_queue),
 		TEST_FUNCTION_ENTRY(test_linked_list),

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -57,7 +57,7 @@ char* test_mps_orthonormalize_qr();
 char* test_mps_compress();
 char* test_mps_split_tensor_svd();
 char* test_mps_to_statevector();
-char* test_mps_deep_copy();
+char* test_copy_mps();
 char* test_ttns_vdot();
 char* test_queue();
 char* test_linked_list();
@@ -144,7 +144,7 @@ int main()
 		TEST_FUNCTION_ENTRY(test_mps_compress),
 		TEST_FUNCTION_ENTRY(test_mps_split_tensor_svd),
 		TEST_FUNCTION_ENTRY(test_mps_to_statevector),
-		TEST_FUNCTION_ENTRY(test_mps_deep_copy),
+		TEST_FUNCTION_ENTRY(test_copy_mps),
 		TEST_FUNCTION_ENTRY(test_ttns_vdot),
 		TEST_FUNCTION_ENTRY(test_queue),
 		TEST_FUNCTION_ENTRY(test_linked_list),

--- a/test/state/test_mps.c
+++ b/test/state/test_mps.c
@@ -727,8 +727,8 @@ char* test_mps_deep_copy() {
 	struct mps copy;
 	mps_deep_copy(&orig, &copy);
 
-	struct block_sparse_tensor psi_vec;
-	mps_to_statevector(&orig, &psi_vec);
+	struct block_sparse_tensor orig_vec;
+	mps_to_statevector(&orig, &orig_vec);
 
 	struct block_sparse_tensor copy_vec;
 	mps_to_statevector(&copy, &copy_vec);
@@ -745,12 +745,12 @@ char* test_mps_deep_copy() {
 		return "qnumbers of the copies are not identical";
 	}
 
-	if (!block_sparse_tensor_allclose(&psi_vec, &copy_vec, 1e-13)) {
+	if (!block_sparse_tensor_allclose(&orig_vec, &copy_vec, 1e-13)) {
 		return "statevectors of the copies are not identical";
 	}
 
 	delete_block_sparse_tensor(&copy_vec);
-	delete_block_sparse_tensor(&psi_vec);
+	delete_block_sparse_tensor(&orig_vec);
 	delete_mps(&copy);
 	delete_mps(&orig);
 

--- a/test/state/test_mps.c
+++ b/test/state/test_mps.c
@@ -706,16 +706,17 @@ char* test_mps_to_statevector()
 }
 
 
-char* test_mps_deep_copy() {
+char* test_copy_mps()
+{
 	const long d = 4;
 	const long nsites = 7;
     
 	const qnumber qsite[] = {
-        encode_quantum_number_pair(0, 0),
-        encode_quantum_number_pair(1, -1),
-        encode_quantum_number_pair(1, 1),
-        encode_quantum_number_pair(2, 0),
-    };
+		encode_quantum_number_pair(0, 0),
+		encode_quantum_number_pair(1, -1),
+		encode_quantum_number_pair(1, 1),
+		encode_quantum_number_pair(2, 0),
+	};
 
 	struct rng_state rng_state;
 	seed_rng_state(42, &rng_state);
@@ -725,7 +726,7 @@ char* test_mps_deep_copy() {
 	construct_random_mps(CT_DOUBLE_COMPLEX, nsites, d, qsite, nsites % 4, max_vdim, &rng_state, &orig);
 
 	struct mps copy;
-	mps_deep_copy(&orig, &copy);
+	copy_mps(&orig, &copy);
 
 	struct block_sparse_tensor orig_vec;
 	mps_to_statevector(&orig, &orig_vec);
@@ -741,7 +742,7 @@ char* test_mps_deep_copy() {
 		return "'nsites' of the copies are not identical";
 	}
 
-	if (!qnumber_all_equal(nsites, orig.qsite, copy.qsite)) {
+	if (!qnumber_all_equal(orig.d, orig.qsite, copy.qsite)) {
 		return "qnumbers of the copies are not identical";
 	}
 

--- a/test/state/test_mps.c
+++ b/test/state/test_mps.c
@@ -704,3 +704,55 @@ char* test_mps_to_statevector()
 
 	return 0;
 }
+
+
+char* test_mps_deep_copy() {
+	const long d = 4;
+	const long nsites = 7;
+    
+	const qnumber qsite[] = {
+        encode_quantum_number_pair(0, 0),
+        encode_quantum_number_pair(1, -1),
+        encode_quantum_number_pair(1, 1),
+        encode_quantum_number_pair(2, 0),
+    };
+
+	struct rng_state rng_state;
+	seed_rng_state(42, &rng_state);
+
+	struct mps orig;
+	const long max_vdim = 16;
+	construct_random_mps(CT_DOUBLE_COMPLEX, nsites, d, qsite, nsites % 4, max_vdim, &rng_state, &orig);
+
+	struct mps copy;
+	mps_deep_copy(&orig, &copy);
+
+	struct block_sparse_tensor psi_vec;
+	mps_to_statevector(&orig, &psi_vec);
+
+	struct block_sparse_tensor copy_vec;
+	mps_to_statevector(&copy, &copy_vec);
+
+	if (orig.d != copy.d) {
+		return "'d' of the copies are not identical";
+	}
+
+	if (orig.nsites != copy.nsites) {
+		return "'nsites' of the copies are not identical";
+	}
+
+	if (!qnumber_all_equal(nsites, orig.qsite, copy.qsite)) {
+		return "qnumbers of the copies are not identical";
+	}
+
+	if (!block_sparse_tensor_allclose(&psi_vec, &copy_vec, 1e-13)) {
+		return "statevectors of the copies are not identical";
+	}
+
+	delete_block_sparse_tensor(&copy_vec);
+	delete_block_sparse_tensor(&psi_vec);
+	delete_mps(&copy);
+	delete_mps(&orig);
+
+	return 0;
+}


### PR DESCRIPTION
Deep copy a matrix product state.

### Changelog
- Add `mps_deep_copy` to mps.c
- Add `test_mps_deep_copy` test_mps.c

> [!NOTE]
> Since the implementation is rather trivial I'm not sure if such a function should be in the library. I guess it's a convenience / library size trade-off. 

